### PR TITLE
Upgrade "dflydev/fig-cookies" into 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '7.1'
+  - '7.3'
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package provides a [Psr-15 middleware](https://www.php-fig.org/psr/psr-15/) allowing to encrypt cookies using [defuse/php-encryption](https://github.com/defuse/php-encryption).
 
-**Require** php >= 7.1
+**Require** php >= 7.3
 
 **Installation** `composer require ellipse/cookie-encryption`
 

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.3",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "dflydev/fig-cookies": "^1.0",
+        "dflydev/fig-cookies": "^3.0",
         "defuse/php-encryption": "^2.1"
     },
     "require-dev": {
-        "kahlan/kahlan": "^4.0",
-        "eloquent/phony-kahlan": "^1.0",
-        "zendframework/zend-diactoros": "^1.6"
+        "kahlan/kahlan": "^5.0",
+        "eloquent/phony-kahlan": "^4.0",
+        "laminas/laminas-diactoros": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/spec/EncryptCookiesMiddleware.spec.php
+++ b/spec/EncryptCookiesMiddleware.spec.php
@@ -10,7 +10,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Defuse\Crypto\Key;
 use Defuse\Crypto\Crypto;
 
-use Zend\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\Response\TextResponse;
 
 use Ellipse\Cookies\EncryptCookiesMiddleware;
 


### PR DESCRIPTION
This pull request upgrades "dflydev/fig-cookies" to 3.0 and because some packages to work on never PHP versions:

| from | to |reason|
|------|----|-------|
|"kahlan/kahlan": "^4.0"|"kahlan/kahlan": "^5.0"|doesn't work on PHP 8.x correctly|
|"eloquent/phony-kahlan": "^1.0"|"eloquent/phony-kahlan": "^4.0"|because of "kahlan/kahlan"|
|"zendframework/zend-diactoros": "^1.6"| "laminas/laminas-diactoros": "^2.0"|PHP compatibility and also because laminas replaced zendframework|

Also, minimal PHP version now is bumped to PHP 7.3


