### PR TITLE
Add Dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Documentation can be found here:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Dependabot is an easy tool to keep up with all dependencies for your library.  More info about what is that you can find here -> https://docs.github.com/en/code-security/dependabot.

This pull request adds a configuration file to enable it to run checks each month.

Probably #1 is needed to make it correctly work - because Dependabot can only upgrade only one package per pull request.